### PR TITLE
Refactorator: Apply makeorcastepsexplicit in pydruid

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,8 +32,7 @@ deploy:
   - name: staging
     legacy: true
     role: lyftpypi-staging-iad-deploy
-    orca:
-      - region: iad
+    orca: []
   - name: production
     legacy: true
     role: lyftpypi-production-iad-deploy


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control run refactorator.run fix -i pydruid -f makeorcastepsexplicit
```
# makeorcastepsexplicit
State of the world before this refactorator:
  - Orca runs implicitly before the actual "deploy" part of `staging` and `canary` deploy steps.
  - Orca may be run explicitly before the actual "deploy" part of certain deploy steps.

Intended state of the world after this refactorator:
  - Orca is run as a LegacyOrca facet targeted in dedicated deploy steps.
  - Implicit orca runs are disabled. Where it would have been a no-op, it's not explicitly disabled.
  - Explicit orca runs that don't match the default are currently left as-is (to be fixed in a future refactorator).

Motivation: In order to migrate the Deploys Jenkins clusters to Kubernetes, we need to eliminate
certain usages of `control`. The way we run orca is one such usage.


For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
