### PR TITLE
deprecation 4.1

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,12 +30,12 @@ tests:
     container: pydruid.test
 deploy:
   - name: staging
-    legacy: true
+    legacy: false
     role: lyftpypi-staging-iad-deploy
     orca: []
     environment: staging
   - name: production
-    legacy: true
+    legacy: false
     role: lyftpypi-production-iad-deploy
     automatic: true
     orca: []


### PR DESCRIPTION
This fork is not in use. Related to https://lyft.slack.com/archives/C07DRU771/p1602184858203500.

Followed instruction 4.1 at https://docs.lyft.net/eng/computedocs/user/V2/service_deprecation.html.